### PR TITLE
Add possibility to use same file as input/output for templates on jwebclient-analyzer plugin

### DIFF
--- a/jwebclient-analyzer-maven-plugin/src/main/java/org/fao/unredd/jwebclientAnalyzer/GenerateRequireJSBuildConfig.java
+++ b/jwebclient-analyzer-maven-plugin/src/main/java/org/fao/unredd/jwebclientAnalyzer/GenerateRequireJSBuildConfig.java
@@ -75,20 +75,13 @@ public class GenerateRequireJSBuildConfig extends AbstractMojo {
 		try {
 			InputStream mainStream = new FileInputStream(mainTemplate);
 			processTemplate(analyzer, mainStream, mainOutputPath);
-			mainStream.close();
 		} catch (IOException e) {
 			throw new MojoExecutionException("Cannot access main template", e);
 		}
 
-		try {
-			InputStream buildStream = getClass().getResourceAsStream(
-					"/buildconfig.js");
-			processTemplate(analyzer, buildStream, buildconfigOutputPath);
-			buildStream.close();
-		} catch (IOException e) {
-			throw new MojoExecutionException(
-					"Cannot access buildconfig template", e);
-		}
+		InputStream buildStream = getClass().getResourceAsStream(
+				"/buildconfig.js");
+		processTemplate(analyzer, buildStream, buildconfigOutputPath);
 	}
 
 	private void processTemplate(JEEContextAnalyzer analyzer,
@@ -100,9 +93,12 @@ public class GenerateRequireJSBuildConfig extends AbstractMojo {
 		RequireTemplate template = new RequireTemplate(templateStream,
 				webResourcesDir, paths, shims, moduleNames);
 		try {
+			String content = template.generate();
+			templateStream.close();
+
 			OutputStream outputStream = new BufferedOutputStream(
 					new FileOutputStream(outputPath));
-			IOUtils.write(template.generate(), outputStream);
+			IOUtils.write(content, outputStream);
 			outputStream.close();
 		} catch (IOException e) {
 		}


### PR DESCRIPTION
We close the input stream before starting to write so we can use the same resource as source template and output file.